### PR TITLE
Restrict s2_par to max workers instead of max chunk size

### DIFF
--- a/src/krc.erl
+++ b/src/krc.erl
@@ -121,7 +121,7 @@ get_index(S, B, I, K, Strat) ->
     end,
   s2_par:map(fun(Key) -> get(S, B, Key, Strat) end,
              Keys,
-             [{errors, false}, {chunksize, 100}]).
+             [{errors, false}, {workers, 10}]).
 
 
 -spec get_index_keys(server(), bucket(), idx(), idx_key()) ->


### PR DESCRIPTION
Instead of saying 'spawn as many concurrent workers as you need to
to never give more than 100 items per worker' we want to say
'split all the tasks among up to 10 workers'
