### PR TITLE
Delete object with vclock

### DIFF
--- a/src/krc.erl
+++ b/src/krc.erl
@@ -25,7 +25,8 @@
 
 %%%_* Exports ==========================================================
 %% API
--export([ delete/3
+-export([ delete/2
+        , delete/3
         , get/3
         , get/4
         , get_bucket/2
@@ -65,6 +66,10 @@
 -type bucket_props() :: props().
 
 %%%_ * API -------------------------------------------------------------
+-spec delete(server(), obj()) -> whynot(_).
+%% @doc Delete O.
+delete(S, O) -> krc_server:delete(S, O).
+
 -spec delete(server(), bucket(), key()) -> whynot(_).
 %% @doc Delete K from B.
 delete(S, B, K) -> krc_server:delete(S, B, K).

--- a/src/krc_pb_client.erl
+++ b/src/krc_pb_client.erl
@@ -24,7 +24,8 @@
 -behaviour(krc_riak_client).
 
 %%%_* Exports ==========================================================
--export([ delete/5
+-export([ delete/4
+        , delete/5
         , get/5
         , get_bucket/3
         , get_index/5
@@ -41,6 +42,14 @@
 -include_lib("riakc/include/riakc.hrl").
 
 %%%_* Code =============================================================
+delete(Pid, Obj, Options, Timeout) ->
+  case
+    riakc_pb_socket:delete_obj(Pid, krc_obj:to_riakc_obj(Obj), Options, Timeout)
+  of
+    ok               -> ok;
+    {error, _} = Err -> Err
+  end.
+
 delete(Pid, Bucket, Key, Options, Timeout) ->
   case
     riakc_pb_socket:delete(

--- a/src/krc_server.erl
+++ b/src/krc_server.erl
@@ -78,7 +78,8 @@
         ]).
 
 %% Riak API
--export([ delete/3
+-export([ delete/2
+        , delete/3
         , get/3
         , get_bucket/2
         , get_index/4
@@ -135,6 +136,7 @@
         }).
 
 %%%_ * API -------------------------------------------------------------
+delete(GS, O)                 -> call(GS, {delete,     [O]      }).
 delete(GS, B, K)              -> call(GS, {delete,     [B, K]   }).
 get(GS, B, K)                 -> call(GS, {get,        [B, K]   }).
 get_bucket(GS, B)             -> call(GS, {get_bucket, [B]      }).


### PR DESCRIPTION
When deleting an object (instead of explicitly specifying bucket and key), `riakc` will use the `vclock` (if any) in the object and delete the value in a manner that typically shouldn't create siblings.