### PR TITLE
fix: Allow range search on '$bucket' index

### DIFF
--- a/src/krc_obj.erl
+++ b/src/krc_obj.erl
@@ -201,6 +201,7 @@ decode(X)                      -> X.
 -spec encode_index({_, _})     -> {binary(), binary()}.
 encode_index({'$bucket',
               '$bucket'})      -> {<<"$bucket">>, <<"$bucket">>};
+encode_index({'$bucket', Key}) -> {<<"$bucket">>, Key};
 encode_index({Idx, Key})
   when is_integer(Key)         -> {encode_idx(Idx,<<"int">>), Key};
 encode_index({Idx, Key})       -> {encode_idx(Idx,<<"bin">>), Key}.


### PR DESCRIPTION
Now this will be possible:

```erl
> loco_filechunk:put(<<"148769066955555555555555555555555555555555">>, <<>>).
ok

> loco_filechunk:get_all_keys().
{ok,[<<"148769066955555555555555555555555555555555">>]}

> krc:get_index_keys(krc_server, <<"filechunk">>, '$bucket', {range, <<"1480000000">>, <<"1490000000">>}, 5000).
{ok,[<<"148769066955555555555555555555555555555555">>]}
```

Exception looked like this:

```erl
{error,{lifted_exn,badarg,
                   [{krc_obj,add_suffix,2,
                             [{file,"/build/kivra_core/_build/default/lib/krc/src/krc_obj.erl"},
                              {line,221}]},
                    {krc_obj,encode_index,1,
                             [{file,"/build/kivra_core/_build/default/lib/krc/src/krc_obj.erl"},
                              {line,206}]},
                    {krc_pb_client,get_index,6,
                                   [{file,"/build/kivra_core/_build/default/lib/krc/src/krc_pb_client.erl"},
                                    {line,95}]},
                    {s2_maybe,lift,1,
                              [{file,"/build/kivra_core/_build/default/lib/stdlib2/src/s2_maybe.erl"},
                               {line,57}]},
                    {krc_server,connection,3,
                                [{file,"/build/kivra_core/_build/default/lib/krc/src/krc_server.erl"},
                                 {line,277}]},
                    {proc_lib,init_p,3,[{file,"proc_lib.erl"},{line,211}]}]}}
```

No suffix should be added for the `$bucket` index like it's done for the other 2i indexes.

A reference to this special index from the Riak docs: https://docs.riak.com/riak/kv/latest/developing/usage/secondary-indexes/index.html#retrieve-all-bucket-keys-via-the-bucket-index