### PR TITLE
fix: Write back resolved result only once and skip second read

### DIFF
--- a/src/krc.erl
+++ b/src/krc.erl
@@ -100,10 +100,12 @@ get_loop(I, N, S, B, K, F) ->
         {{ok, NewObj},   true}  ->
           ?increment([resolve, ok]),
           case krc_obj:val(NewObj) of
-            ?TOMBSTONE -> ok = delete(S, NewObj),
-                          {error, notfound};
-            _Val       -> {ok, VObj} = put(S, NewObj, write_back_opts()),
-                          {ok, krc_obj:set_vclock(NewObj, krc_obj:vclock(VObj))}
+            ?TOMBSTONE ->
+              ok = delete(S, NewObj),
+              {error, notfound};
+            _Val ->
+              {ok, VObj} = put(S, NewObj, write_back_opts()),
+              {ok, krc_obj:set_vclock(NewObj, krc_obj:vclock(VObj))}
           end
       end;
     {error, notfound} ->

--- a/src/krc.erl
+++ b/src/krc.erl
@@ -90,25 +90,20 @@ get(S, B, K, F) when is_function(F) ->
   end.
 
 get_loop(S, B, K, F) ->
-  get_loop(1, get_tries(), S, B, K, F, false).
-get_loop(I, N, S, B, K, F, R) ->
+  get_loop(1, get_tries(), S, B, K, F).
+get_loop(I, N, S, B, K, F) ->
   case krc_server:get(S, B, K) of
     {ok, Obj} ->
-      case {krc_obj:resolve(Obj, F), krc_obj:siblings(Obj), R} of
-        {Ret, false, _} -> Ret; % No resolve needed
-        {{error, _} = E, _, _} -> E; % Resolve failed
-        {{ok, NewObj}, true, false} -> % First resolve
+      case {krc_obj:resolve(Obj, F), krc_obj:siblings(Obj)} of
+        {Ret,            false} -> Ret;
+        {{error, _} = E, _}     -> E;
+        {{ok, NewObj},   true}  ->
           ?increment([resolve, ok]),
           case krc_obj:val(NewObj) of
-            ?TOMBSTONE -> ok = delete(S, NewObj);
-            _Val       -> ok = put(S, NewObj)
-          end,
-          get_loop(I, N, S, B, K, F, true);
-        {{ok, NewObj} = Ret, true, true} -> % Second resolve
-          ?increment([resolve, ok]),
-          case krc_obj:val(NewObj) of
-            ?TOMBSTONE -> {error, notfound};
-            _Val       -> Ret
+            ?TOMBSTONE -> ok = delete(S, NewObj),
+                          {error, notfound};
+            _Val       -> {ok, VObj} = put(S, NewObj, write_back_put_opts()),
+                          {ok, krc_obj:set_vclock(NewObj, krc_obj:vclock(VObj))}
           end
       end;
     {error, notfound} ->
@@ -121,7 +116,7 @@ get_loop(I, N, S, B, K, F, R) ->
       ?error("{~p, ~p} error: ~p, attempt ~p of ~p", [B, K, Rsn, I, N]),
       ?increment([read, retries]),
       timer:sleep(retry_wait_ms()),
-      get_loop(I+1, N, S, B, K, F, R);
+      get_loop(I+1, N, S, B, K, F);
     {error, _} = Err when N =:= I ->
       Err
   end.
@@ -224,6 +219,11 @@ put_tries() -> s2_env:get_arg([], ?APP, put_tries, 1).
 
 %% @doc This many ms in-between tries.
 retry_wait_ms() -> s2_env:get_arg([], ?APP, retry_wait_ms, 20).
+
+%% @docs Opts for the write-back of a resolved value. Return head so
+%%       that we obtain the new vector clock from the 'put'.
+write_back_put_opts() ->
+  krc_server:opts(put) ++ [return_head].
 
 %%%_* Tests ============================================================
 -ifdef(TEST).

--- a/src/krc.erl
+++ b/src/krc.erl
@@ -102,7 +102,7 @@ get_loop(I, N, S, B, K, F) ->
           case krc_obj:val(NewObj) of
             ?TOMBSTONE -> ok = delete(S, NewObj),
                           {error, notfound};
-            _Val       -> {ok, VObj} = put(S, NewObj, write_back_put_opts()),
+            _Val       -> {ok, VObj} = put(S, NewObj, write_back_opts()),
                           {ok, krc_obj:set_vclock(NewObj, krc_obj:vclock(VObj))}
           end
       end;
@@ -222,8 +222,8 @@ retry_wait_ms() -> s2_env:get_arg([], ?APP, retry_wait_ms, 20).
 
 %% @docs Opts for the write-back of a resolved value. Return head so
 %%       that we obtain the new vector clock from the 'put'.
-write_back_put_opts() ->
-  krc_server:opts(put) ++ [return_head].
+write_back_opts() ->
+  krc_server:wopts() ++ [return_head].
 
 %%%_* Tests ============================================================
 -ifdef(TEST).

--- a/src/krc.erl
+++ b/src/krc.erl
@@ -90,47 +90,39 @@ get(S, B, K, F) when is_function(F) ->
   end.
 
 get_loop(S, B, K, F) ->
-  get_loop(1, get_tries(), S, B, K, F).
-get_loop(I, N, S, B, K, F) when N > I ->
+  get_loop(1, get_tries(), S, B, K, F, false).
+get_loop(I, N, S, B, K, F, R) ->
   case krc_server:get(S, B, K) of
     {ok, Obj} ->
-      case {krc_obj:resolve(Obj, F), krc_obj:siblings(Obj)} of
-        {Ret,            false} -> Ret;
-        {{error, _} = E, _}     -> E;
-        {{ok, NewObj},   true}  ->
+      case {krc_obj:resolve(Obj, F), krc_obj:siblings(Obj), R} of
+        {Ret, false, _} -> Ret; % No resolve needed
+        {{error, _} = E, _, _} -> E; % Resolve failed
+        {{ok, NewObj}, true, false} -> % First resolve
           ?increment([resolve, ok]),
           case krc_obj:val(NewObj) of
             ?TOMBSTONE -> ok = delete(S, NewObj);
             _Val       -> ok = put(S, NewObj)
           end,
-          get_loop(I+1, N, S, B, K, F)
-      end;
-    {error, notfound} ->
-      {error, notfound};
-    %% This shouldn't happen since we are stoping requests with empty key
-    %% but anyway we shouldn't retry if the error was due to empty key.
-    {error, <<"Key cannot be zero-length">>} = Err ->
-      Err;
-    {error, Rsn}      ->
-      ?error("{~p, ~p} error: ~p, attempt ~p of ~p", [B, K, Rsn, I, N]),
-      ?increment([read, retries]),
-      timer:sleep(retry_wait_ms()),
-      get_loop(I+1, N, S, B, K, F)
-  end;
-get_loop(I, N, S, B, K, F) when N =:= I ->
-  case krc_server:get(S, B, K) of
-    {ok, Obj} ->
-      case {krc_obj:resolve(Obj, F), krc_obj:siblings(Obj)} of
-        {Ret,                false} -> Ret;
-        {{error, _} = E,     _}     -> E;
-        {{ok, NewObj} = Ret, true}  ->
+          get_loop(I, N, S, B, K, F, true);
+        {{ok, NewObj} = Ret, true, true} -> % Second resolve
           ?increment([resolve, ok]),
           case krc_obj:val(NewObj) of
             ?TOMBSTONE -> {error, notfound};
             _Val       -> Ret
           end
       end;
-    {error, _}=Err ->
+    {error, notfound} ->
+      {error, notfound};
+    %% This shouldn't happen since we are stopping requests with empty key
+    %% but anyway we shouldn't retry if the error was due to empty key.
+    {error, <<"Key cannot be zero-length">>} = Err ->
+      Err;
+    {error, Rsn} when N > I ->
+      ?error("{~p, ~p} error: ~p, attempt ~p of ~p", [B, K, Rsn, I, N]),
+      ?increment([read, retries]),
+      timer:sleep(retry_wait_ms()),
+      get_loop(I+1, N, S, B, K, F, R);
+    {error, _} = Err when N =:= I ->
       Err
   end.
 

--- a/src/krc_server.erl
+++ b/src/krc_server.erl
@@ -103,6 +103,7 @@
 %% Internal exports
 -export([ connection/3
         , opts/1
+        , wopts/0
         ]).
 
 %%%_* Includes =========================================================


### PR DESCRIPTION
With `get_tries` of 3 or more it's a big chance that multiple "write-backs" of resolved values will happen in situations with many concurrent updates to an object. That's just causing more siblings and slow things down which in turn also causes more siblings.

Also, there's no need for a second 'get'. One can just obtain the new vector clock from the 'put'. Similar to how it's done in `db.erl`:

https://github.com/kivra/kivra_core/blob/1a6d8284ad9a85afe5a1ea02cf2c053ebae9da5d/src/kivra_core/db.erl#L347-L349

https://github.com/kivra/kivra_core/blob/1a6d8284ad9a85afe5a1ea02cf2c053ebae9da5d/src/kivra_core/db.erl#L596-L601

https://github.com/kivra/krc/blob/8a9add6b3d037dfbc6b00e6ee734e71c168e81d2/src/krc_server.erl#L361-L365

One could of course make the write-back optional but it was not really optional before either (unless one set `get_tries` to 1 which would have avoided the write-back). Thus I went for the simple solution of always having it.

Green build in Kivra Core:
* https://github.com/kivra/kivra_core/pull/4592