### PR TITLE
fix: Avoid put_loop on write-back and treat 'modified' errors differently

### DIFF
--- a/src/krc.erl
+++ b/src/krc.erl
@@ -104,7 +104,7 @@ get_loop(I, N, S, B, K, F) ->
               ok = delete(S, NewObj),
               {error, notfound};
             _Val ->
-              case put(S, NewObj, write_back_opts()) of
+              case krc_server:put(S, NewObj, write_back_opts()) of
                 {ok, VObj} ->
                   {ok, krc_obj:set_vclock(NewObj, krc_obj:vclock(VObj))};
                 %% No need for write-back during concurrent updates of the

--- a/src/krc.erl
+++ b/src/krc.erl
@@ -113,7 +113,7 @@ get_loop(I, N, S, B, K, F) ->
                 {error, <<"modified">>} ->
                   {ok, NewObj};
                 {error, Rsn} ->
-                  ?error("Write-back after resolve failed, error: ~p", [B, K, Rsn]),
+                  ?error("Write-back after resolve failed, error: ~p", [Rsn]),
                   {ok, NewObj}
               end
           end

--- a/src/krc_server.erl
+++ b/src/krc_server.erl
@@ -289,6 +289,10 @@ connection(Client, Pid, Daddy) ->
               ?debug("notfound", []),
               ?increment([requests, notfound]),
               gen_server:reply(From, Err);
+            {error, <<"modified">>} = Err ->
+              ?debug("modified", []),
+              ?increment([requests, modified]),
+              gen_server:reply(From, Err);
             {error, Rsn} = Err ->
               ?error("error: ~p", [Rsn]),
               ?increment([requests, errors]),


### PR DESCRIPTION
See https://github.com/kivra/krc/pull/22 for more context.