### PR TITLE
feature: move to telemetry events to report stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc
 /deps
 .emacs*
 _build
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .eunit
 doc
 /deps
+.emacs*
+_build

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ The application emits the following `telemetry` events:
 
 - `[krc_pb_client, request, stop]` emitted at the end of a request to riak
   - Measurement: `#{duration => integer(), monotonic_time => integer()}`
-  - Metadata: `#{request => map(), response => ok | error, error => term()}`
+  - Metadata: `#{request => map(), response => map()}`

--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ jakob@moody.primat.es:~/git/erlang/krc$ gmake test
 * krc_server.erl      -- worker pool
 * krc_sup.erl         -- supervisor
 * krc_test.erl        -- test support
+
+## Telemetry Events
+
+
+The application emits the following `telemetry` events:
+
+- `[krc, get, conflict]` emitted when a conflict has been encountered during read.
+  - Measurement: `#{monotonic_time => integer(), system_time => integer()}`
+  - Metadata: `#{result => ok | error, error => term(), bucket => B, key => K}`
+
+- `[krc, 'operation', retry]` (`operation` can be `get` or `put`) emitted when a get retry is made
+  - Measurement: `#{monotonic_time => integer(), system_time => integer()}`
+  - Metadata: `#{retry => positive_integer(), retry_limit => positive_integer(), bucket => binary(), key => binary(), error => term()}`
+
+- `[krc_server, process, error]` emitted when a process terminates
+  - Measurement: `#{monotonic_time => integer(), system_time => integer()}`
+  - Metadata: `#{pid => pid(), reason => term(), failure_count => non_neg_integer()}`
+
+- `[krc_server, request, stop]` emitted when a request terminates
+  - Measurement: `#{monotonic_time => integer(), system_time => integer()}`
+  - Metadata: `#{pid => pid(), client => atom(), daddy => pid(), result => ok | error, error => term()}`
+
+- `[krc_pb_client, request, stop]` emitted at the end of a request to riak
+  - Measurement: `#{duration => integer(), monotonic_time => integer()}`
+  - Metadata: `#{request => map(), response => ok | error, error => term()}`

--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,11 @@
  , { riakc
    , ""
    , {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.3"}}
-   },
-   {telemetry, "~> 1.2"}
+   }
+
+ %% Metrics
+ , { telemetry, "~> 1.2" }
+ , { prometheus, "4.10.0" }
  ]}.
 
 {overrides,

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,8 @@
  , { riakc
    , ""
    , {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.3"}}
-   }
+   },
+   {telemetry, "~> 1.2"}
  ]}.
 
 {overrides,

--- a/src/krc.app.src
+++ b/src/krc.app.src
@@ -6,6 +6,7 @@
                                     , stdlib
                                     , stdlib2
                                     , riakc
+                                    , prometheus
                                     , telemetry
                                     ]}
                    , {mod,          {krc_app, []}}

--- a/src/krc.app.src
+++ b/src/krc.app.src
@@ -6,6 +6,7 @@
                                     , stdlib
                                     , stdlib2
                                     , riakc
+                                    , telemetry
                                     ]}
                    , {mod,          {krc_app, []}}
                    ]}.

--- a/src/krc_obj.erl
+++ b/src/krc_obj.erl
@@ -48,6 +48,7 @@
         , set_val/2
         , set_vclock/2
         , set_indices/2
+        , is_obj/1
         ]).
 
 -export_type([ bucket/0
@@ -102,6 +103,10 @@ indices(#krc_obj{indices=I}) -> I.
 
 -spec vclock(ect()) -> _.
 vclock(#krc_obj{vclock=C})   -> C.
+
+-spec is_obj(term()) -> boolean().
+is_obj(#krc_obj{}) -> true;
+is_obj(_) -> false.
 
 -spec siblings(ect()) -> boolean().
 siblings(Obj)                -> length(val(Obj)) =/= 1.

--- a/src/krc_pb_client.erl
+++ b/src/krc_pb_client.erl
@@ -37,43 +37,111 @@
         , start_link/3
         ]).
 
+%%%_* Define ===========================================================
+-define(TELEMETRY_EVENT, [?MODULE, request]).
+
 %%%_* Includes =========================================================
 -include_lib("stdlib2/include/prelude.hrl").
 -include_lib("riakc/include/riakc.hrl").
 
 %%%_* Code =============================================================
+start_link(IP, Port, Options) ->
+  {ok, Pid} = riakc_pb_socket:start_link(IP, Port, Options),
+  pong      = riakc_pb_socket:ping(Pid), %ensure server actually reachable
+  {ok, Pid}.
+
 delete(Pid, Obj, Options, Timeout) ->
-  case
-    riakc_pb_socket:delete_obj(Pid, krc_obj:to_riakc_obj(Obj), Options, Timeout)
-  of
-    ok               -> ok;
-    {error, _} = Err -> Err
-  end.
+  obj_exec(Pid, delete_obj, Obj, Options, Timeout).
 
 delete(Pid, Bucket, Key, Options, Timeout) ->
-  case
-    riakc_pb_socket:delete(
-      Pid, krc_obj:encode(Bucket), krc_obj:encode(Key), Options, Timeout)
-  of
-    ok               -> ok;
-    {error, _} = Err -> Err
-  end.
+  obj_exec(Pid, delete, Bucket, Key, Options, Timeout).
 
 get(Pid, Bucket, Key, Options, Timeout) ->
-  case
-    riakc_pb_socket:get(
-      Pid, krc_obj:encode(Bucket), krc_obj:encode(Key), Options, Timeout)
-  of
-    {ok, Obj}        -> {ok, krc_obj:from_riakc_obj(Obj)};
-    {error, _} = Err -> Err
-  end.
+  obj_exec(Pid, get, Bucket, Key, Options, Timeout).
+
+putwo(Pid, Obj, Options, Timeout) -> put(Pid, Obj, Options, Timeout).
+put(Pid, Obj, Options, Timeout)   ->
+  obj_exec(Pid, put, Obj, Options, Timeout).
+
+get_index(Pid, Bucket, Index, Key, Timeout) ->
+  {Idx, IdxKey} = krc_obj:encode_index({Index, Key}),
+  ExtraMetadata = #{index => Index, idx => Idx, idxkey => IdxKey},
+  StartMetadata = metadata(Pid, get_index_eq, Bucket, Key, [], Timeout, ExtraMetadata),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp = riakc_pb_socket:get_index_eq(Pid,
+                                            krc_obj:encode(Bucket),
+                                            Idx,
+                                            IdxKey,
+                                            [{timeout, Timeout}, {stream, true}]),
+        handle_resp(Resp, StartMetadata, fun handle_stream/1)
+    end
+   ).
+
+get_index(Pid, Bucket, Index, Lower, Upper, Timeout) ->
+  {Idx, LowerKey} = krc_obj:encode_index({Index, Lower}),
+  {Idx, UpperKey} = krc_obj:encode_index({Index, Upper}),
+  ExtraMetadata = #{index => Index, idx => Idx, lower_key => LowerKey, upper_key => UpperKey},
+  StartMetadata = metadata(Pid, get_index_range, Bucket, undefined, [], Timeout, ExtraMetadata),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp =
+          riakc_pb_socket:get_index_range(Pid,
+                                          krc_obj:encode(Bucket),
+                                          Idx,
+                                          LowerKey,
+                                          UpperKey,
+                                          [{timeout, Timeout}, {stream, true}]),
+        handle_resp(Resp, StartMetadata, fun handle_stream/1)
+    end
+   ).
+
+list_keys(Pid, Bucket, Timeout) ->
+  StartMetadata = metadata(Pid, list_keys, Bucket, undefined, [], Timeout),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp = riakc_pb_socket:list_keys(Pid, krc_obj:encode(Bucket), Timeout),
+        handle_resp(Resp, StartMetadata, fun(Keys) -> {ok, Keys} end)
+    end
+  ).
 
 get_bucket(Pid, Bucket, Timeout) ->
-  case
-    riakc_pb_socket:get_bucket(Pid,
-                   krc_obj:encode(Bucket),
-                   Timeout) of
-    {ok, Props}      -> {ok, krc_bucket_properties:decode(Props)};
+  StartMetadata = metadata(Pid, get_bucket, Bucket, undefined, [], Timeout),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp = riakc_pb_socket:get_bucket(Pid, krc_obj:encode(Bucket), Timeout),
+        handle_resp(
+          Resp,
+          StartMetadata,
+          fun(Props) -> {ok, krc_bucket_properties:decode(Props)} end
+         )
+    end
+   ).
+
+set_bucket(Pid, Bucket, Props, Timeout) ->
+  ExtraMetadata = #{props => Props},
+  StartMetadata = metadata(Pid, set_bucket, Bucket, undefined, [], Timeout, ExtraMetadata),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp = riakc_pb_socket:set_bucket(Pid, krc_obj:encode(Bucket), Props, Timeout),
+        handle_resp(Resp, StartMetadata)
+    end
+   ).
+
+%%%_* Private ==========================================================
+handle_stream(ReqId) ->
+  case wait_for_list(ReqId) of
+    {ok, Res}        ->  {ok, [krc_obj:decode(K) || K <- Res]};
     {error, _} = Err -> Err
   end.
 
@@ -87,67 +155,90 @@ wait_for_list(ReqId, Acc) ->
     {ReqId, Res} -> wait_for_list(ReqId, [Res?INDEX_STREAM_RESULT.keys | Acc])
   end.
 
-handle_stream(ReqId) ->
-  case wait_for_list(ReqId) of
-    {ok, Res}        ->  {ok, [krc_obj:decode(K) || K <- Res]};
-    {error, _} = Err -> Err
+obj_exec(Pid, Op, Obj, Options, Timeout) ->
+  StartMetadata = metadata(Pid, Op, Obj, Options, Timeout),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp =
+          riakc_pb_socket:Op(Pid, krc_obj:to_riakc_obj(Obj), Options, Timeout),
+        handle_resp(Resp, StartMetadata)
+    end
+   ).
+
+obj_exec(Pid, Op, Bucket, Key, Options, Timeout) ->
+  StartMetadata = metadata(Pid, Op, Bucket, Key, Options, Timeout),
+  telemetry:span(
+    ?TELEMETRY_EVENT,
+    StartMetadata,
+    fun() ->
+        Resp =
+          riakc_pb_socket:Op(
+            Pid,
+            krc_obj:encode(Bucket),
+            krc_obj:encode(Key),
+            Options,
+            Timeout
+           ),
+        handle_resp(Resp, StartMetadata)
+    end
+   ).
+
+handle_resp(Resp, StartMetadata) ->
+  handle_resp(Resp, StartMetadata, fun(Obj) -> {ok, krc_obj:from_riakc_obj(Obj)} end).
+
+handle_resp(ok, StartMetadata, _DecodeRespFun) ->
+  RespMetadata = #{response => #{result => ok}},
+  {ok, maps:merge(StartMetadata, RespMetadata)};
+handle_resp({ok, RespObj}, StartMetadata, DecodeRespFun) ->
+  Resp = DecodeRespFun(RespObj),
+  RespMetadata =
+    case Resp of
+      {ok, Data} -> #{response => #{result => ok, size => size_in_bytes(Data)}};
+      {error, Reason} -> #{response => #{result => error, error => Reason}}
+    end,
+  {Resp, maps:merge(StartMetadata, RespMetadata)};
+handle_resp({error, Reason}, StartMetadata, _DecodeRespFun) ->
+  RespMetadata = #{response => #{result => error, error => Reason}},
+  {{error, Reason}, maps:merge(StartMetadata, RespMetadata)}.
+
+metadata(Pid, Op, Obj, Options, Timeout) ->
+  ExtraMetadata = #{size => size_in_bytes(Obj)},
+  metadata(Pid, Op, krc_obj:bucket(Obj), krc_obj:key(Obj), Options, Timeout, ExtraMetadata).
+
+metadata(Pid, Op, Bucket, Key, Options, Timeout) ->
+  metadata(Pid, Op, Bucket, Key, Options, Timeout, #{}).
+
+metadata(Pid, Op, Bucket, Key, Options, Timeout, ExtraMetadata) ->
+  BaseMetadata =
+    #{
+      pid => Pid,
+      method => Op,
+      bucket => Bucket,
+      key => Key,
+      opts => Options,
+      timeout => Timeout
+     },
+
+  #{request => maps:merge(BaseMetadata, ExtraMetadata)}.
+
+size_in_bytes(Data) ->
+  case krc_obj:is_obj(Data) of
+    true -> krc_obj_size(Data);
+    false -> term_size(Data)
   end.
 
-get_index(Pid, Bucket, Index, Key, Timeout) ->
-  {Idx, IdxKey} = krc_obj:encode_index({Index, Key}),
-  case
-    riakc_pb_socket:get_index_eq(Pid,
-                                 krc_obj:encode(Bucket),
-                                 Idx,
-                                 IdxKey,
-                                 [{timeout, Timeout}, {stream, true}])
-  of
-    {ok, ReqId}      -> handle_stream(ReqId);
-    {error, _} = Err -> Err
-  end.
+krc_obj_size(Obj) ->
+  term_size(krc_obj:val(Obj)).
 
-get_index(Pid, Bucket, Index, Lower, Upper, Timeout) ->
-  {Idx, LowerKey} = krc_obj:encode_index({Index, Lower}),
-  {Idx, UpperKey} = krc_obj:encode_index({Index, Upper}),
-  case
-    riakc_pb_socket:get_index_range(Pid,
-                                    krc_obj:encode(Bucket),
-                                    Idx,
-                                    LowerKey,
-                                    UpperKey,
-                                    [{timeout, Timeout}, {stream, true}])
-  of
-    {ok, ReqId}        ->  handle_stream(ReqId);
-    {error, _} = Err -> Err
-  end.
-
-list_keys(Pid, Bucket, Timeout) ->
-    riakc_pb_socket:list_keys(Pid, krc_obj:encode(Bucket), Timeout).
-
-putwo(Pid, Obj, Options, Timeout) -> put(Pid, Obj, Options, Timeout).
-put(Pid, Obj, Options, Timeout)   ->
-  case
-    riakc_pb_socket:put(Pid, krc_obj:to_riakc_obj(Obj), Options, Timeout)
-  of
-    ok               -> ok;
-    {ok, Res}        -> {ok, krc_obj:from_riakc_obj(Res)};
-    {error, _} = Err -> Err
-  end.
-
-set_bucket(Pid, Bucket, Props, Timeout) ->
-  case
-    riakc_pb_socket:set_bucket(Pid,
-                   krc_obj:encode(Bucket),
-                   Props,
-                   Timeout) of
-    ok               -> ok;
-    {error, _} = Err -> Err
-  end.
-
-start_link(IP, Port, Options) ->
-  {ok, Pid} = riakc_pb_socket:start_link(IP, Port, Options),
-  pong      = riakc_pb_socket:ping(Pid), %ensure server actually reachable
-  {ok, Pid}.
+term_size(Data) when is_binary(Data) ->
+  erlang:iolist_size(Data);
+term_size(Data) ->
+  %% From the docs: Calculates, without doing the encoding, the maximum
+  %% byte size for a term encoded in the Erlang external term format
+  %% TODO: Is there a better way to do this?
+  erlang:external_size(Data).
 
 %%%_* Tests ============================================================
 -ifdef(TEST).

--- a/src/krc_prometheus.erl
+++ b/src/krc_prometheus.erl
@@ -10,6 +10,12 @@
 %%%_* Module declaration ===============================================
 -module(krc_prometheus).
 
+%%%_* Define ===========================================================
+%% Taken from
+%%    https://github.com/akoutmos/prom_ex/blob/master/lib/prom_ex/plugins/plug_router.ex#L191
+%% But we may want to redefine these depending on what we get in the metrics
+-define(BYTE_SIZE_BUCKETS, [64, 512, 4096, 65536, 262144, 1048576, 4194304, 16777216]).
+
 %%%_* Exports ==========================================================
 -export([declare_metrics/0]).
 -export([conflict_count/2]).
@@ -58,19 +64,13 @@ declare_metrics() ->
   prometheus_histogram:declare([
     {name, krc_request_size_bytes},
     {labels, [result, operation, bucket]},
-    %% Beware bucket resolution, but let's just use the defaults until we make an informed decision:
-    %% https://medium.com/mercari-engineering/have-you-been-using-histogram-metrics-correctly-730c9547a7a9
-    %% The default buckets are floats representing seconds.
-    {buckets, default},
+    {buckets, ?BYTE_SIZE_BUCKETS},
     {help, "Riak client request size"}
   ]),
   prometheus_histogram:declare([
     {name, krc_response_size_bytes},
     {labels, [result, operation, bucket]},
-    %% Beware bucket resolution, but let's just use the defaults until we make an informed decision:
-    %% https://medium.com/mercari-engineering/have-you-been-using-histogram-metrics-correctly-730c9547a7a9
-    %% The default buckets are floats representing seconds.
-    {buckets, default},
+    {buckets, ?BYTE_SIZE_BUCKETS},
     {help, "Riak client response size"}
   ]),
   ok.

--- a/src/krc_prometheus.erl
+++ b/src/krc_prometheus.erl
@@ -1,0 +1,115 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% @doc Prometheus metric definitions for KRC
+%%%
+%%% This module requires that the top level application already set ups
+%%% prometheus metrics using `prometheus` library
+%%%
+%%% @end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%_* Module declaration ===============================================
+-module(krc_prometheus).
+
+%%%_* Exports ==========================================================
+-export([declare_metrics/0]).
+-export([conflict_count/2]).
+-export([process_error_count/0]).
+-export([retry_count/2]).
+-export([request_count/2]).
+-export([request_duration/4]).
+-export([request_size/4]).
+-export([response_size/4]).
+
+%%%_* Code =============================================================
+-spec declare_metrics() -> ok.
+declare_metrics() ->
+  %% The names are chosen according to these guides:
+  %% https://github.com/deadtrickster/prometheus.erl/blob/master/doc/prometheus_time.md#description
+  %% https://prometheus.io/docs/practices/naming/#metric-names
+  prometheus_counter:declare([
+    {name, krc_conflict_total},
+    {labels, [result, bucket]},
+    {help, "Client conflict count"}
+  ]),
+  prometheus_counter:declare([
+    {name, krc_retries_total},
+    {labels, [operation, bucket]},
+    {help, "Client retry count per request"}
+  ]),
+  prometheus_counter:declare([
+    {name, krc_request_total},
+    {labels, [result, error]},
+    {help, "Client request count"}
+  ]),
+  prometheus_counter:declare([
+    {name, krc_process_error_total},
+    {labels, []},
+    {help, "Client process error count"}
+  ]),
+  prometheus_histogram:declare([
+    {name, krc_request_duration_seconds},
+    {labels, [result, operation, bucket]},
+    %% Beware bucket resolution, but let's just use the defaults until we make an informed decision:
+    %% https://medium.com/mercari-engineering/have-you-been-using-histogram-metrics-correctly-730c9547a7a9
+    %% The default buckets are floats representing seconds.
+    {buckets, default},
+    {help, "Client request duration"}
+  ]),
+  prometheus_histogram:declare([
+    {name, krc_request_size_bytes},
+    {labels, [result, operation, bucket]},
+    %% Beware bucket resolution, but let's just use the defaults until we make an informed decision:
+    %% https://medium.com/mercari-engineering/have-you-been-using-histogram-metrics-correctly-730c9547a7a9
+    %% The default buckets are floats representing seconds.
+    {buckets, default},
+    {help, "Riak client request size"}
+  ]),
+  prometheus_histogram:declare([
+    {name, krc_response_size_bytes},
+    {labels, [result, operation, bucket]},
+    %% Beware bucket resolution, but let's just use the defaults until we make an informed decision:
+    %% https://medium.com/mercari-engineering/have-you-been-using-histogram-metrics-correctly-730c9547a7a9
+    %% The default buckets are floats representing seconds.
+    {buckets, default},
+    {help, "Riak client response size"}
+  ]),
+  ok.
+
+-spec conflict_count(atom(), binary()) -> any().
+conflict_count(Result, Bucket) ->
+    prometheus_counter:inc(krc_conflict_total, [Result, Bucket], 1).
+
+-spec retry_count(atom(), binary()) -> any().
+retry_count(Op, Bucket) ->
+    prometheus_counter:inc(krc_retries_total, [Op, Bucket], 1).
+
+-spec request_count(atom(), atom()) -> any().
+request_count(Result, Error) ->
+    prometheus_counter:inc(krc_request_total, [Result, Error], 1).
+
+-spec process_error_count() -> any().
+process_error_count() ->
+    prometheus_counter:inc(krc_process_error_total, [], 1).
+
+-spec request_duration(pos_integer(), atom(), binary(), binary()) -> any().
+request_duration(DurationNative, Result, Op, Bucket) ->
+    prometheus_histogram:observe(
+      krc_request_duration_seconds,
+      [Result, Op, Bucket], DurationNative
+     ).
+
+-spec request_size(pos_integer(), atom(), binary(), binary()) -> any().
+request_size(SizeInBytes, Result, Op, Bucket) ->
+    prometheus_histogram:observe(
+      krc_request_size_bytes,
+      [Result, Op, Bucket], SizeInBytes
+     ).
+
+-spec response_size(pos_integer(), atom(), binary(), binary()) -> any().
+response_size(SizeInBytes, Result, Op, Bucket) ->
+    prometheus_histogram:observe(
+      krc_response_size_bytes,
+      [Result, Op, Bucket], SizeInBytes
+     ).
+
+%%%_* Private ==========================================================


### PR DESCRIPTION
## Description

At the moment, the library uses `stdlib2` to report metrics which doesn't work as the system moved to `prometheus`. 

In this PR, the metrics are replaced with `telemetry` events that allow the main application to decide what to do with them: create metrics or logs.