### PR TITLE
fix: Move from `maybe` to `'maybe'` to prevent OTP 27 compile issues

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
    }
  , { riakc
    , ""
-   , {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.3"}}
+   , {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.4"}}
    }
 
  %% Metrics
@@ -32,5 +32,6 @@
                  , {platform_define, "(?=^[0-9]+)(?!^17)", deprecated_now}
                  , {platform_define, "^(19|[2-9])", deprecated_19}
                  ]}
-    ]}
+    ]},
+   {override, hamcrest, [ {plugins, []} ]}
  ]}.

--- a/src/krc.erl
+++ b/src/krc.erl
@@ -77,8 +77,8 @@ delete(S, O) -> krc_server:delete(S, O).
 delete(S, B, K) -> krc_server:delete(S, B, K).
 
 
--spec get(server(), bucket(), key())             -> maybe(obj(), _).
--spec get(server(), bucket(), key(), strategy()) -> maybe(obj(), _).
+-spec get(server(), bucket(), key())             -> 'maybe'(obj(), _).
+-spec get(server(), bucket(), key(), strategy()) -> 'maybe'(obj(), _).
 %% @doc Fetch the object associated with K in B.
 get(S, B, K) ->
   get(S, B, K, krc_policy_default).
@@ -153,14 +153,14 @@ maybe_resolve_obj(S, B, K, F, Obj, WB) ->
       end
   end.
 
--spec get_bucket(server(), bucket()) -> maybe(bucket_props(), _).
+-spec get_bucket(server(), bucket()) -> 'maybe'(bucket_props(), _).
 get_bucket(S, B) ->
   krc_server:get_bucket(S, B).
 
 -spec get_index(server(), bucket(), idx(), idx_key()) ->
-                   maybe([obj()], _).
+                   'maybe'([obj()], _).
 -spec get_index(server(), bucket(), idx(), idx_key(), strategy()) ->
-                   maybe([obj()], _).
+                   'maybe'([obj()], _).
 %% @doc Get all objects tagged with I in bucket B.
 get_index(S, B, I, K) ->
   get_index(S, B, I, K, krc_policy_default).
@@ -176,7 +176,7 @@ get_index(S, B, I, K, Strat) ->
 
 
 -spec get_index_keys(server(), bucket(), idx(), idx_key()) ->
-                        maybe([key()], _).
+                        'maybe'([key()], _).
 %% @doc Get all keys tagged with I in bucket B.
 get_index_keys(S, B, I, K) ->
     get_index_keys(S, B, I, K, ?CALL_TIMEOUT).
@@ -188,7 +188,7 @@ get_index_keys(S, B, I, K, T) ->
   end.
 
 
--spec list_keys(server(), bucket()) -> maybe([key()], _).
+-spec list_keys(server(), bucket()) -> 'maybe'([key()], _).
 %% @doc Get all keys from a bucket B.
 list_keys(S, B) -> krc_server:list_keys(S, B).
 

--- a/src/krc_obj.erl
+++ b/src/krc_obj.erl
@@ -184,7 +184,7 @@ decode_indices(MD) ->
 
 %% @doc Resolve conflicts by computing the LUB of all values and
 %% indices under F.
--spec resolve(ect(), fun((_, _) -> maybe(_, _))) -> maybe(ect(), _).
+-spec resolve(ect(), fun((_, _) -> 'maybe'(_, _))) -> 'maybe'(ect(), _).
 resolve(#krc_obj{val=Vs, indices=Is} = Obj, F) ->
   ?lift(Obj#krc_obj{ val     = ?unlift(s2_maybe:reduce(F, Vs))
                    , indices = ?unlift(s2_maybe:reduce(F, Is))

--- a/src/krc_resolver.erl
+++ b/src/krc_resolver.erl
@@ -36,11 +36,11 @@
 
 %%%_* Code =============================================================
 %%%_ * Types -----------------------------------------------------------
--type resolution_procedure() :: fun((A, A) -> maybe(A, _)).
+-type resolution_procedure() :: fun((A, A) -> 'maybe'(A, _)).
 -type resolver()             :: module().
 
 %%%_ * Behaviour -------------------------------------------------------
--callback resolve(A, A) -> maybe(A, _).
+-callback resolve(A, A) -> 'maybe'(A, _).
 
 %%%_ * API -------------------------------------------------------------
 -spec compose([resolver()]) -> resolution_procedure().

--- a/src/krc_server.erl
+++ b/src/krc_server.erl
@@ -333,7 +333,7 @@ time_left(T0) ->
   ElapsedMs = (T1 - T0) / 1000,
   lists:max([?QUEUE_TIMEOUT - ElapsedMs, 0]).
 
--spec do(atom(), pid(), {atom(), [_]}) -> maybe(_, _).
+-spec do(atom(), pid(), {atom(), [_]}) -> 'maybe'(_, _).
 do(Client, Pid, {F, A}) ->
     do(Client, Pid, {F, A}, ?CALL_TIMEOUT);
 do(Client, Pid, {F, A, T}) ->


### PR DESCRIPTION
Depends on https://github.com/kivra/riak-erlang-client/pull/1.