### PR TITLE
chore: support riak credentials parameters

### DIFF
--- a/src/krc.erl
+++ b/src/krc.erl
@@ -470,7 +470,7 @@ conflict_ok_test() ->
     {ok, Obj} = get(krc_server,
                     B,
                     K,
-                    fun(V1, V2) -> erlang:max(V1, V2) end),
+                    fun(Val1, Val2) -> erlang:max(Val1, Val2) end),
     true      = erlang:max(V1, V2) =:= krc_obj:val(Obj)
   end).
 


### PR DESCRIPTION
## Description

Support `riak` credentials when creating `riak` connections