### PR TITLE
no-release: Don't blame on recent formatting change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Project-wide erlfmt formatting
+e62a563a375318a77251887075c54d5dbdd81bec


### PR DESCRIPTION
## Motivation

Avoid blame on recent formatting changes.

## Description

Ease future blaming.

## Further considerations

I ran `git config --global blame.ignoreRevsFile .git-blame-ignore-revs` locally (not sure that that file name is "standard" - but it seems to be widely used -, so I copied it from `kivra-in-a-box`) to always ignore blame in a consistent way.