### PR TITLE
no-release: Don't blame on recent formatting change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Project-wide erlfmt formatting
 e62a563a375318a77251887075c54d5dbdd81bec
+6d5d856e271c18e8c31634f022bc59af2a160f71


### PR DESCRIPTION
## Motivation

Avoid blame on recent un-formatting changes.

## Description

Ease future blaming.

## Further considerations

I ran `git config --global blame.ignoreRevsFile .git-blame-ignore-revs` locally (not sure that that file name is "standard" - but it seems to be widely used -, so I copied it from `kivra-in-a-box`) to always ignore blame in a consistent way.