### PR TITLE
chore: update riakc to '2.5.6'

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,7 @@
 
 {deps,
  [ { stdlib2, {git, "git@github.com:kivra/stdlib2.git", {tag, "v1.4.6"}} }
- , { riakc, {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.4"}} }
+ , { riakc, {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.6"}} }
 
  %% Metrics
  , { telemetry, "~> 1.2" }

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,7 +11,7 @@
   1},
  {<<"riakc">>,
   {git,"git@github.com:kivra/riak-erlang-client.git",
-       {ref,"675098b50052508ab7be09198b023a2648c061ee"}},
+       {ref,"8313902e4aaef7a160312ffe4bf812b6eb99de03"}},
   0},
  {<<"stdlib2">>,
   {git,"git@github.com:kivra/stdlib2.git",


### PR DESCRIPTION
## Description

Updates `riak` client version which adds `format_status` callback to `riakc_pb_socket` to remove credentials (see https://github.com/kivra/riak-erlang-client/pull/2)