### PR TITLE
fix(test-public-ci): have a working public CI for regression testing purposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+---
+name: ci
+
+on:
+  # for feature branches
+  pull_request:
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: erlef/setup-beam@v1.18.2
+        with:
+          otp-version: 26
+          rebar3-version: 3.24
+
+      - run: make ci

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ all: deps
 deps:
 	rebar3 get-deps
 
-docs:
-	rebar3 doc
-
 dialyzer:
 	rebar3 dialyzer
 
@@ -28,6 +25,5 @@ xref:
 
 clean:
 	rebar3 clean
-	$(RM) doc/*
 
 # eof

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 suite=$(if $(SUITE), suite=$(SUITE), )
 
-.PHONY:	all deps check test clean
+.PHONY:	all ci deps check test clean
 
 all: deps
 	rebar3 compile
+
+ci: clean xref dialyzer up test down
+.NOTPARALLEL: ci up test down
 
 deps:
 	rebar3 get-deps

--- a/rebar.config
+++ b/rebar.config
@@ -23,8 +23,8 @@
 ]}.
 
 {deps,
- [ { stdlib2, {git, "git@github.com:kivra/stdlib2.git", {tag, "v1.4.6"}} }
- , { riakc, {git, "git@github.com:kivra/riak-erlang-client.git", {tag, "2.5.7"}} }
+ [ { stdlib2, {git, "https://github.com/kivra/stdlib2.git", {tag, "v1.4.6"}} }
+ , { riakc, {git, "https://github.com/kivra/riak-erlang-client.git", {tag, "2.5.7"}} }
 
  %% Metrics
  , { telemetry, "~> 1.2" }

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,11 +10,11 @@
        {ref,"08771aba2ce4935b715d32d1b92555efdc3da994"}},
   1},
  {<<"riakc">>,
-  {git,"git@github.com:kivra/riak-erlang-client.git",
+  {git,"https://github.com/kivra/riak-erlang-client.git",
        {ref,"9773e1582bb7af16d1b4e45a946d40cc42bf38bd"}},
   0},
  {<<"stdlib2">>,
-  {git,"git@github.com:kivra/stdlib2.git",
+  {git,"https://github.com/kivra/stdlib2.git",
        {ref,"f5fdd13de0f02d7b1f9482133a7e4bf8cce14974"}},
   0},
  {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.3.0">>},0}]}.


### PR DESCRIPTION
# Motivation

Increased developer confidence.

# Description

We increase our confidence in changes to this by having CI run in GitHub Actions.

# Further considerations

I remove `doc`-relates Make elements since:

1. it's not working
3. even with a few fixes it'd mean changing the code to appease EDoc (which was already discontinued next to Erlang)