### PR TITLE
chore: disable notfound ok for reads (needed to address issues with failing nodes)

### DIFF
--- a/src/krc_server.erl
+++ b/src/krc_server.erl
@@ -399,7 +399,7 @@ ropts() ->
   [ {r,               quorum}        %\ Majority
   , {pr,              1}             %/ reads
   , {basic_quorum,    false}
-  , {notfound_ok,     true}
+  , {notfound_ok,     false}      %% CHANGE BACK to true
   ].
 
 %% Writes


### PR DESCRIPTION
## Description

Due to failing riak nodes, this needs to be disabled