### PR TITLE
no-release(fix): enable `forkProcessing` for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "forkProcessing": "enabled",
   "extends": [
     "config:best-practices",
     ":disableDigestUpdates"


### PR DESCRIPTION
# Motivation

Build on the results from https://github.com/kivra/krc/pull/42.

# Description

Renovate's CI seems to indicate we might be missing the now-added option.