### PR TITLE
fix: Renovate further

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "forkProcessing": "enabled",
-  "extends": [
-    "config:best-practices",
-    ":disableDigestUpdates"
-  ]
-}


### PR DESCRIPTION
# Motivation

Allow Renovate to properly identify our requirements.

# Description

Uses `renovate.json5` instead of `renovate.json`. If `renovate.json` is present it takes precedence over the previous file.