### PR TITLE
fix: `push` on `rebar.lock` update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ name: ci
 on:
   # for feature branches
   pull_request:
+  # for rebar.lock updates
+  push:
+    branches:
+      - renovate/**
 
 concurrency:
   group: ${{ (github.ref != 'refs/heads/master') && format('{0}-{1}', github.ref, github.workflow) || github.run_id }}


### PR DESCRIPTION
# Motivation

Have Renovate PRs be able to push to repository, triggering CI.