### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 ---
 name: ci
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   # for feature branches


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/krc/security/code-scanning/6](https://github.com/kivra/krc/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `pull-requests: write` for handling Renovate PRs and pushing updates to `rebar.lock`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `ci` job to limit its scope. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
